### PR TITLE
Speed up filter

### DIFF
--- a/src/FastDict.elm
+++ b/src/FastDict.elm
@@ -860,17 +860,8 @@ foldrInner func acc t =
 {-| Keep only the key-value pairs that pass the given test.
 -}
 filter : (comparable -> v -> Bool) -> Dict comparable v -> Dict comparable v
-filter isGood dict =
-    foldl
-        (\k v d ->
-            if isGood k v then
-                insert k v d
-
-            else
-                d
-        )
-        empty
-        dict
+filter =
+    filter2
 
 
 filter2 : (comparable -> v -> Bool) -> Dict comparable v -> Dict comparable v


### PR DESCRIPTION
I was wondering whether it was possible to make `Dict.filter` faster, and I figured I'd try it on your version first.

Today we fold and insert, which creates many many intermediate copies of `Dict`, as well as many traversals for the insertion step.

The idea is to traverse the tree and remove elements as we go back up the tree. It's not tail-call recursive but I think for RB trees that might not be super important.

So the results are... pretty good :smirk: 

![Screenshot from 2025-06-04 17-46-06](https://github.com/user-attachments/assets/6861cb45-30f4-453c-925a-cf79193793d4)
![Screenshot from 2025-06-04 17-45-33](https://github.com/user-attachments/assets/2281afc3-8795-43b3-94b7-e4543c633fb0)
![Screenshot from 2025-06-04 17-38-34](https://github.com/user-attachments/assets/d15d0ad0-406e-4ce7-9da7-6c02f520a2c7)


**But**, some RB trees invariants are broken (as pointed out by the thorough tests), and maybe making them pass again will mess up the performance, I'm not sure.
I'm having some trouble figuring out what I'm doing wrong. I figured I'd share this already.

I also think it's possible to improve this slightly by combining `getMinInner` and `removeMin2` into one operation, but I'm struggling a bit with that as well at the moment :sweat_smile: 