### PR TITLE
Faster insertNoReplace and FastSet.insert

### DIFF
--- a/src/FastDict.elm
+++ b/src/FastDict.elm
@@ -442,7 +442,7 @@ insertHelp key value dict =
                         ( newLeft, isNew ) =
                             insertHelp key value nLeft
                     in
-                    ( balance nColor nKey nValue newLeft nRight, isNew )
+                    ( Internal.balance nColor nKey nValue newLeft nRight, isNew )
 
                 EQ ->
                     ( InnerNode nColor nKey value nLeft nRight, False )
@@ -452,7 +452,7 @@ insertHelp key value dict =
                         ( newRight, isNew ) =
                             insertHelp key value nRight
                     in
-                    ( balance nColor nKey nValue nLeft newRight, isNew )
+                    ( Internal.balance nColor nKey nValue nLeft newRight, isNew )
 
 
 insertHelpNoReplace : comparable -> v -> InnerDict comparable v -> ( InnerDict comparable v, Bool )
@@ -470,7 +470,7 @@ insertHelpNoReplace key value dict =
                         ( newLeft, isNew ) =
                             insertHelpNoReplace key value nLeft
                     in
-                    ( balance nColor nKey nValue newLeft nRight, isNew )
+                    ( Internal.balance nColor nKey nValue newLeft nRight, isNew )
 
                 EQ ->
                     ( dict, False )
@@ -480,37 +480,7 @@ insertHelpNoReplace key value dict =
                         ( newRight, isNew ) =
                             insertHelpNoReplace key value nRight
                     in
-                    ( balance nColor nKey nValue nLeft newRight, isNew )
-
-
-balance : NColor -> k -> v -> InnerDict k v -> InnerDict k v -> InnerDict k v
-balance color key value left right =
-    case right of
-        InnerNode Red rK rV rLeft rRight ->
-            case left of
-                InnerNode Red lK lV lLeft lRight ->
-                    InnerNode
-                        Red
-                        key
-                        value
-                        (InnerNode Black lK lV lLeft lRight)
-                        (InnerNode Black rK rV rLeft rRight)
-
-                _ ->
-                    InnerNode color rK rV (InnerNode Red key value left rLeft) rRight
-
-        _ ->
-            case left of
-                InnerNode Red lK lV (InnerNode Red llK llV llLeft llRight) lRight ->
-                    InnerNode
-                        Red
-                        lK
-                        lV
-                        (InnerNode Black llK llV llLeft llRight)
-                        (InnerNode Black key value lRight right)
-
-                _ ->
-                    InnerNode color key value left right
+                    ( Internal.balance nColor nKey nValue nLeft newRight, isNew )
 
 
 {-| Remove a key-value pair from a dictionary. If the key is not found,
@@ -573,7 +543,7 @@ removeHelp targetKey dict =
                                     ( newLeft, wasMember ) =
                                         removeHelp targetKey res.left
                                 in
-                                ( balance res.color res.k res.v newLeft res.right, wasMember )
+                                ( Internal.balance res.color res.k res.v newLeft res.right, wasMember )
 
                     _ ->
                         let
@@ -622,7 +592,7 @@ removeHelpEQGT targetKey dict =
             if targetKey == key then
                 case getMinInner right of
                     Just ( minKey, minValue ) ->
-                        ( balance color minKey minValue left (removeMin right), True )
+                        ( Internal.balance color minKey minValue left (removeMin right), True )
 
                     Nothing ->
                         ( Leaf, True )
@@ -632,7 +602,7 @@ removeHelpEQGT targetKey dict =
                     ( newRight, wasMember ) =
                         removeHelp targetKey right
                 in
-                ( balance color key value left newRight, wasMember )
+                ( Internal.balance color key value left newRight, wasMember )
 
         Leaf ->
             ( Leaf, False )
@@ -654,7 +624,7 @@ removeMin dict =
                                 res =
                                     moveRedLeft color key value left right
                             in
-                            balance res.color res.k res.v (removeMin res.left) res.right
+                            Internal.balance res.color res.k res.v (removeMin res.left) res.right
 
                 _ ->
                     InnerNode color key value (removeMin left) right

--- a/src/FastDict.elm
+++ b/src/FastDict.elm
@@ -392,34 +392,10 @@ insert key value (Dict sz dict) =
         Dict sz result
 
 
-insertNoReplace : comparable -> v -> Dict comparable v -> Dict comparable v
-insertNoReplace key value (Dict sz dict) =
-    let
-        ( result, isNew ) =
-            insertInnerNoReplace key value dict
-    in
-    if isNew then
-        Dict (sz + 1) result
-
-    else
-        Dict sz result
-
-
 insertInner : comparable -> v -> InnerDict comparable v -> ( InnerDict comparable v, Bool )
 insertInner key value dict =
     -- Root node is always Black
     case insertHelp key value dict of
-        ( InnerNode Red k v l r, isNew ) ->
-            ( InnerNode Black k v l r, isNew )
-
-        x ->
-            x
-
-
-insertInnerNoReplace : comparable -> v -> InnerDict comparable v -> ( InnerDict comparable v, Bool )
-insertInnerNoReplace key value dict =
-    -- Root node is always Black
-    case insertHelpNoReplace key value dict of
         ( InnerNode Red k v l r, isNew ) ->
             ( InnerNode Black k v l r, isNew )
 
@@ -451,34 +427,6 @@ insertHelp key value dict =
                     let
                         ( newRight, isNew ) =
                             insertHelp key value nRight
-                    in
-                    ( Internal.balance nColor nKey nValue nLeft newRight, isNew )
-
-
-insertHelpNoReplace : comparable -> v -> InnerDict comparable v -> ( InnerDict comparable v, Bool )
-insertHelpNoReplace key value dict =
-    case dict of
-        Leaf ->
-            -- New nodes are always red. If it violates the rules, it will be fixed
-            -- when balancing.
-            ( InnerNode Red key value Leaf Leaf, True )
-
-        InnerNode nColor nKey nValue nLeft nRight ->
-            case compare key nKey of
-                LT ->
-                    let
-                        ( newLeft, isNew ) =
-                            insertHelpNoReplace key value nLeft
-                    in
-                    ( Internal.balance nColor nKey nValue newLeft nRight, isNew )
-
-                EQ ->
-                    ( dict, False )
-
-                GT ->
-                    let
-                        ( newRight, isNew ) =
-                            insertHelpNoReplace key value nRight
                     in
                     ( Internal.balance nColor nKey nValue nLeft newRight, isNew )
 
@@ -718,7 +666,7 @@ union ((Dict s1 _) as t1) ((Dict s2 _) as t2) =
     -- else
     --     Union.union t1 t2
     if s1 > s2 then
-        foldl insertNoReplace t1 t2
+        foldl Internal.insertNoReplace t1 t2
 
     else
         foldl insert t2 t1

--- a/src/FastSet.elm
+++ b/src/FastSet.elm
@@ -66,7 +66,7 @@ Insert, remove, and query operations all take _O(log n)_ time.
 -}
 
 import FastDict
-import Internal exposing (Dict(..), InnerDict(..), NColor(..))
+import Internal
 import Set
 
 
@@ -212,39 +212,6 @@ isEmpty (Set set) =
 insert : comparable -> Set comparable -> Set comparable
 insert value (Set set) =
     Set (Internal.insertNoReplace value False set)
-
-
-insertHelp : comparable -> InnerDict comparable Bool -> Maybe (InnerDict comparable Bool)
-insertHelp key set =
-    case set of
-        Leaf ->
-            -- New nodes are always red. If it violates the rules, it will be fixed
-            -- when balancing.
-            InnerNode Internal.Red key False Leaf Leaf
-                |> Just
-
-        InnerNode nColor nKey nValue nLeft nRight ->
-            case compare key nKey of
-                LT ->
-                    case insertHelp key nLeft of
-                        Just sub ->
-                            Internal.balance nColor nKey nValue sub nRight
-                                |> Just
-
-                        Nothing ->
-                            Nothing
-
-                EQ ->
-                    Nothing
-
-                GT ->
-                    case insertHelp key nRight of
-                        Just sub ->
-                            Internal.balance nColor nKey nValue nLeft sub
-                                |> Just
-
-                        Nothing ->
-                            Nothing
 
 
 {-| Remove a value from a set. If the value is not found,

--- a/src/FastSet.elm
+++ b/src/FastSet.elm
@@ -66,6 +66,7 @@ Insert, remove, and query operations all take _O(log n)_ time.
 -}
 
 import FastDict
+import Internal exposing (Dict(..), InnerDict(..), NColor(..))
 import Set
 
 
@@ -210,7 +211,40 @@ isEmpty (Set set) =
 -}
 insert : comparable -> Set comparable -> Set comparable
 insert value (Set set) =
-    Set (FastDict.insert value False set)
+    Set (Internal.insertNoReplace value False set)
+
+
+insertHelp : comparable -> InnerDict comparable Bool -> Maybe (InnerDict comparable Bool)
+insertHelp key set =
+    case set of
+        Leaf ->
+            -- New nodes are always red. If it violates the rules, it will be fixed
+            -- when balancing.
+            InnerNode Internal.Red key False Leaf Leaf
+                |> Just
+
+        InnerNode nColor nKey nValue nLeft nRight ->
+            case compare key nKey of
+                LT ->
+                    case insertHelp key nLeft of
+                        Just sub ->
+                            Internal.balance nColor nKey nValue sub nRight
+                                |> Just
+
+                        Nothing ->
+                            Nothing
+
+                EQ ->
+                    Nothing
+
+                GT ->
+                    case insertHelp key nRight of
+                        Just sub ->
+                            Internal.balance nColor nKey nValue nLeft sub
+                                |> Just
+
+                        Nothing ->
+                            Nothing
 
 
 {-| Remove a value from a set. If the value is not found,

--- a/src/Internal.elm
+++ b/src/Internal.elm
@@ -1,4 +1,4 @@
-module Internal exposing (Dict(..), InnerDict(..), NColor(..), VisitQueue, fromSortedList, unconsBiggest, unconsBiggestWhileDroppingGT)
+module Internal exposing (Dict(..), InnerDict(..), NColor(..), VisitQueue, balance, fromSortedList, unconsBiggest, unconsBiggestWhileDroppingGT)
 
 import ListWithLength exposing (ListWithLength)
 
@@ -133,3 +133,33 @@ unconsBiggestWhileDroppingGT compareKey queue =
 
                 Leaf ->
                     unconsBiggestWhileDroppingGT compareKey t
+
+
+balance : NColor -> k -> v -> InnerDict k v -> InnerDict k v -> InnerDict k v
+balance color key value left right =
+    case right of
+        InnerNode Red rK rV rLeft rRight ->
+            case left of
+                InnerNode Red lK lV lLeft lRight ->
+                    InnerNode
+                        Red
+                        key
+                        value
+                        (InnerNode Black lK lV lLeft lRight)
+                        (InnerNode Black rK rV rLeft rRight)
+
+                _ ->
+                    InnerNode color rK rV (InnerNode Red key value left rLeft) rRight
+
+        _ ->
+            case left of
+                InnerNode Red lK lV (InnerNode Red llK llV llLeft llRight) lRight ->
+                    InnerNode
+                        Red
+                        lK
+                        lV
+                        (InnerNode Black llK llV llLeft llRight)
+                        (InnerNode Black key value lRight right)
+
+                _ ->
+                    InnerNode color key value left right


### PR DESCRIPTION
This makes it so that `FastSet.insert` now uses `FastDict.insertNoReplace` instead of `FastDict.insert`, since there's no need to do any replacement if the key is already in the Set.

That led to a small performance improvement (Chrome):
![image](https://github.com/user-attachments/assets/6beec980-d2f0-442b-b84f-3eb74341e005)

I then noticed than `insertNoReplace` constructs a new `Dict`, regardless of whether the value is new or not (and then discards it entirely). Similar to #5, I've changed the function to only construct the `Dict` if necessary.

That means that there is less memory being allocated to create a new `Dict`.

That results in the following performance changes ([benchmark](https://github.com/jfmengels/elm-fast-dict/tree/faster-insert-benchmark)):
(Chrome)
![Screenshot from 2025-06-06 14-59-47](https://github.com/user-attachments/assets/cdc4a8cc-be67-4844-909b-0f0db609d024)
(FireFox)
![Screenshot from 2025-06-06 14-59-37](https://github.com/user-attachments/assets/4e14b355-8adf-4866-98c0-77ddbf33b429)

Performance is slightly slower when there are no duplicates in the (because it's the same algorithm with a tiny bit more overhead potentially), but better if there are duplicates (in the benchmark, there's 5 copies of every number).

This should speed up functions that use `insertNoReplace` or `FastSet.insert`:
- `FastDict.union`
- `FastSet.fromList`
- `FastSet.map`

By the way, I've moved `insertNoReplace` to `Internal` to be able to call it from `FastSet`, but potentially it could be exposed as part of the public API. Not sure it's worth doing but that's another option.

NOTE: I think the same technique could be applied to `elm/core`'s `Set` as well.