### PR TITLE
Faster FastDict.remove

### DIFF
--- a/src/FastDict.elm
+++ b/src/FastDict.elm
@@ -432,23 +432,13 @@ no changes are made.
 -}
 remove : comparable -> Dict comparable v -> Dict comparable v
 remove key ((Dict sz dict) as orig) =
-    case removeInner key dict of
+    -- Root node is always Black
+    case removeHelp key dict of
         Just result ->
-            Dict (sz - 1) result
+            Dict (sz - 1) (Internal.setRootBlack result)
 
         Nothing ->
             orig
-
-
-removeInner : comparable -> InnerDict comparable v -> Maybe (InnerDict comparable v)
-removeInner key dict =
-    -- Root node is always Black
-    case removeHelp key dict of
-        Just (InnerNode Red k v l r) ->
-            Just (InnerNode Black k v l r)
-
-        x ->
-            x
 
 
 {-| The easiest thing to remove from the tree, is a red node. However, when searching for the

--- a/src/FastDict.elm
+++ b/src/FastDict.elm
@@ -395,12 +395,8 @@ insert key value (Dict sz dict) =
 insertInner : comparable -> v -> InnerDict comparable v -> ( InnerDict comparable v, Bool )
 insertInner key value dict =
     -- Root node is always Black
-    case insertHelp key value dict of
-        ( InnerNode Red k v l r, isNew ) ->
-            ( InnerNode Black k v l r, isNew )
-
-        x ->
-            x
+    insertHelp key value dict
+        |> Tuple.mapFirst Internal.setRootBlack
 
 
 insertHelp : comparable -> v -> InnerDict comparable v -> ( InnerDict comparable v, Bool )

--- a/src/Internal.elm
+++ b/src/Internal.elm
@@ -1,4 +1,4 @@
-module Internal exposing (Dict(..), InnerDict(..), NColor(..), VisitQueue, balance, fromSortedList, insertNoReplace, unconsBiggest, unconsBiggestWhileDroppingGT)
+module Internal exposing (Dict(..), InnerDict(..), NColor(..), VisitQueue, balance, fromSortedList, insertNoReplace, setRootBlack, unconsBiggest, unconsBiggestWhileDroppingGT)
 
 import ListWithLength exposing (ListWithLength)
 


### PR DESCRIPTION
This makes it so that we don't create a new dict when calling `Dict.remove` unless the key was found. Before this change, we would create the new tree and then throw it away anyway.

Performance changes: ([benchmark](https://github.com/jfmengels/elm-fast-dict/tree/faster-remove-benchmark)):
The last benchmark's title is "1000 elements, remove all but half are missing".

(Chrome)
![Screenshot from 2025-06-06 19-34-06](https://github.com/user-attachments/assets/392d7821-fadb-4350-a146-482e2996b21a)

(Firefox)
![Screenshot from 2025-06-06 19-41-01](https://github.com/user-attachments/assets/f84476e3-b1bb-4d63-8cbc-f2e4c545c408)

This should make `FastDict.diff` faster, as well as `FastSet.remove/diff`