### PR TITLE
Better test failure messages

### DIFF
--- a/tests/Combine.elm
+++ b/tests/Combine.elm
@@ -4,8 +4,8 @@ import Expect
 import FastDict as Dict exposing (Dict)
 import Fuzz
 import Fuzzers exposing (Key, Value, dictFuzzer, keyFuzzer)
-import Invariants exposing (respectsInvariantsFuzz)
-import Test exposing (Test, describe, fuzz2, fuzz3)
+import Invariants exposing (expectDictRespectsInvariants)
+import Test exposing (Test, describe, fuzz, fuzz2, fuzz3)
 
 
 suite : Test
@@ -24,10 +24,6 @@ unionTest =
         unionFuzzer : Fuzz.Fuzzer ( Dict Key Value, Dict Key Value )
         unionFuzzer =
             Fuzz.pair dictFuzzer dictFuzzer
-
-        unionedFuzzer : Fuzz.Fuzzer (Dict Key Value)
-        unionedFuzzer =
-            Fuzz.map2 Dict.union dictFuzzer dictFuzzer
     in
     describe "union"
         [ fuzz2 unionFuzzer keyFuzzer "Contains the correct values giving preference to the first" <|
@@ -60,7 +56,10 @@ unionTest =
         --     \( first, second ) key ->
         --         Dict.member key (Dict.union first second)
         --             |> Expect.equal (Dict.member key first || Dict.member key second)
-        , respectsInvariantsFuzz identity unionedFuzzer
+        , fuzz unionFuzzer "Respects the invariants" <|
+            \( first, second ) ->
+                Dict.union first second
+                    |> expectDictRespectsInvariants
         ]
 
 
@@ -70,10 +69,6 @@ intersectTest =
         intersectFuzzer : Fuzz.Fuzzer ( Dict Key Value, Dict Key Value )
         intersectFuzzer =
             Fuzz.pair dictFuzzer dictFuzzer
-
-        intersectedFuzzer : Fuzz.Fuzzer (Dict Key Value)
-        intersectedFuzzer =
-            Fuzz.map2 Dict.intersect dictFuzzer dictFuzzer
     in
     describe "intersect"
         [ fuzz2 intersectFuzzer keyFuzzer "Contains the correct values giving preference to the first" <|
@@ -106,7 +101,10 @@ intersectTest =
         --     \( first, second ) key ->
         --         Dict.member key (Dict.intersect first second)
         --             |> Expect.equal (Dict.member key first && Dict.member key second)
-        , respectsInvariantsFuzz identity intersectedFuzzer
+        , fuzz intersectFuzzer "Respects the invariants" <|
+            \( first, second ) ->
+                Dict.intersect first second
+                    |> expectDictRespectsInvariants
         ]
 
 
@@ -116,10 +114,6 @@ diffTest =
         diffFuzzer : Fuzz.Fuzzer ( Dict Key Value, Dict Key Value )
         diffFuzzer =
             Fuzz.pair dictFuzzer dictFuzzer
-
-        diffedFuzzer : Fuzz.Fuzzer (Dict Key Value)
-        diffedFuzzer =
-            Fuzz.map2 Dict.diff dictFuzzer dictFuzzer
     in
     describe "diff"
         [ fuzz2 diffFuzzer keyFuzzer "Contains the correct values giving preference to the first" <|
@@ -144,7 +138,10 @@ diffTest =
             \( first, second ) key ->
                 Dict.member key (Dict.diff first second)
                     |> Expect.equal (Dict.member key first && not (Dict.member key second))
-        , respectsInvariantsFuzz identity diffedFuzzer
+        , fuzz diffFuzzer "Respects the invariants" <|
+            \( first, second ) ->
+                Dict.diff first second
+                    |> expectDictRespectsInvariants
         ]
 
 

--- a/tests/Invariants.elm
+++ b/tests/Invariants.elm
@@ -1,26 +1,8 @@
-module Invariants exposing (expectDictRespectsInvariants, hasCorrectSize, respectsInvariantsFuzz)
+module Invariants exposing (expectDictRespectsInvariants, hasCorrectSize)
 
 import Expect exposing (Expectation)
-import Fuzz exposing (Fuzzer)
 import Internal exposing (Dict(..), InnerDict(..), NColor(..))
-import Test exposing (Test, fuzz)
 import Test.Runner
-
-
-{-| Checks whether a dictionary respects the five invariants:
-
-1.  the root is black
-2.  the cached size is the amount of inner nodes
-3.  the tree is a BST
-4.  the black height is equal on all branches
-5.  no red node has a red child
-
--}
-respectsInvariantsFuzz : (a -> Dict comparable value) -> Fuzzer a -> Test
-respectsInvariantsFuzz f fuzzer =
-    fuzz fuzzer "Respects the invariants" <|
-        \dict ->
-            expectDictRespectsInvariants (f dict)
 
 
 {-| Checks whether a dictionary respects the five invariants:

--- a/tests/Invariants.elm
+++ b/tests/Invariants.elm
@@ -43,55 +43,6 @@ expectDictRespectsInvariants dict =
         ()
 
 
-explainError : Dict k v -> String -> Expectation -> Expectation
-explainError (Dict size dict) prefix expectation =
-    expectation
-        |> onFail (\() -> prefix ++ ":\n\nSize: " ++ String.fromInt size ++ "\n" ++ printTree 0 dict "")
-
-
-printTree : Int -> InnerDict k v -> String -> String
-printTree level dict acc =
-    case dict of
-        Leaf ->
-            acc
-
-        InnerNode color key value left right ->
-            printTree (level + 1)
-                right
-                (printTree (level + 1)
-                    left
-                    (acc
-                        ++ "\n"
-                        ++ String.repeat level "    "
-                        ++ String.join " "
-                            [ "↳"
-                            , colorToString color
-                            , Debug.toString key ++ "->" ++ Debug.toString value
-                            ]
-                    )
-                )
-
-
-colorToString : NColor -> String
-colorToString color =
-    case color of
-        Red ->
-            "R"
-
-        Black ->
-            "B"
-
-
-onFail : (() -> String) -> Expectation -> Expectation
-onFail message expectation =
-    case Test.Runner.getFailureReason expectation of
-        Just _ ->
-            expectation |> Expect.onFail (message ())
-
-        Nothing ->
-            expectation
-
-
 hasCorrectSize : Dict comparable v -> Expectation
 hasCorrectSize (Dict sz dict) =
     let
@@ -205,3 +156,52 @@ noRedChildOfRedNode (Dict _ dict) =
                     go l && go r
     in
     go dict
+
+
+explainError : Dict k v -> String -> Expectation -> Expectation
+explainError (Dict size dict) prefix expectation =
+    expectation
+        |> onFail (\() -> prefix ++ ":\n\nSize: " ++ String.fromInt size ++ "\n" ++ printTree 0 dict "")
+
+
+printTree : Int -> InnerDict k v -> String -> String
+printTree level dict acc =
+    case dict of
+        Leaf ->
+            acc
+
+        InnerNode color key value left right ->
+            printTree (level + 1)
+                right
+                (printTree (level + 1)
+                    left
+                    (acc
+                        ++ "\n"
+                        ++ String.repeat level "    "
+                        ++ String.join " "
+                            [ "↳"
+                            , colorToString color
+                            , Debug.toString key ++ "->" ++ Debug.toString value
+                            ]
+                    )
+                )
+
+
+colorToString : NColor -> String
+colorToString color =
+    case color of
+        Red ->
+            "R"
+
+        Black ->
+            "B"
+
+
+onFail : (() -> String) -> Expectation -> Expectation
+onFail message expectation =
+    case Test.Runner.getFailureReason expectation of
+        Just _ ->
+            expectation |> Expect.onFail (message ())
+
+        Nothing ->
+            expectation

--- a/tests/Lists.elm
+++ b/tests/Lists.elm
@@ -3,7 +3,7 @@ module Lists exposing (suite)
 import Expect
 import FastDict as Dict
 import Fuzzers exposing (Key, dictFuzzer, pairListFuzzer)
-import Invariants exposing (respectsInvariantsFuzz)
+import Invariants exposing (expectDictRespectsInvariants)
 import Test exposing (Test, describe, fuzz)
 
 
@@ -111,7 +111,9 @@ fromListTest =
         --                     |> Dict.fromList
         --                     |> Dict.toList
         --                 )
-        , respectsInvariantsFuzz identity dictFuzzer
+        , fuzz dictFuzzer "Respects the invariants" <|
+            \dict ->
+                expectDictRespectsInvariants dict
         ]
 
 

--- a/tests/Transform.elm
+++ b/tests/Transform.elm
@@ -4,7 +4,7 @@ import Common exposing (expectEqual)
 import Expect
 import FastDict as Dict
 import Fuzzers exposing (Key, Value, dictFuzzer)
-import Invariants exposing (expectDictRespectsInvariants, respectsInvariantsFuzz)
+import Invariants exposing (expectDictRespectsInvariants)
 import Test exposing (Test, describe, fuzz)
 
 
@@ -53,7 +53,11 @@ mapTest =
                                     |> Dict.map f
                                     |> Dict.size
                                     |> Expect.equal (Dict.size dict)
-                        , respectsInvariantsFuzz (Dict.map f) dictFuzzer
+                        , fuzz dictFuzzer "Respects the invariants" <|
+                            \dict ->
+                                dict
+                                    |> Dict.map f
+                                    |> expectDictRespectsInvariants
                         ]
                             |> describe flabel
                     )
@@ -150,6 +154,20 @@ partitionTest =
                     , \_ -> expectEqual er r
                     ]
                     ()
-        , describe "first" [ respectsInvariantsFuzz (Dict.partition f >> Tuple.first) dictFuzzer ]
-        , describe "second" [ respectsInvariantsFuzz (Dict.partition f >> Tuple.second) dictFuzzer ]
+        , describe "first"
+            [ fuzz dictFuzzer "Respects the invariants" <|
+                \dict ->
+                    dict
+                        |> Dict.partition f
+                        |> Tuple.first
+                        |> expectDictRespectsInvariants
+            ]
+        , describe "second"
+            [ fuzz dictFuzzer "Respects the invariants" <|
+                \dict ->
+                    dict
+                        |> Dict.partition f
+                        |> Tuple.second
+                        |> expectDictRespectsInvariants
+            ]
         ]


### PR DESCRIPTION
The test suite in the repo is really extensive which gives some really good confidence when tests pass.

Unfortunately, I found that the error messages were really unhelpful.

```
↓ Transform
↓ transform
↓ filter
↓ Respects the invariants
✗ The black height is consistent

Given Dict 2 (InnerNode Black "2" 2 Leaf (InnerNode Black "4" 4 Leaf Leaf))

    Nothing
    ╷
    │ Expect.notEqual
    ╵
    Nothing
```

Since fuzz tests are often written like this: `fuzz (Fuzz.map (Dict.filter f) dictFuzzer)`, when the test fails, `elm-test` gives the already filtered dict as the "Given" input. But we don't know what the dict before that was.

I have changed all tests so that
1. the operation is applied **after** the tests starts, preserving the original input
2. We don't have many tests and fuzz tests for each invariant that needs to be respected. Instead we have one fuzz test (per operation) that checks all invariants are still okay. (This does make it so that we only get to know about 1 problem at a time)
3. Some of the tests (`filter`) also assert invariants in the regular tests (maybe it could be done in more places, I haven't been very thorough here I think)
4. We now print a nice tree of the result (potentially this could be done for the input as well)

This is the result:

```
↓ Transform
↓ transform
↓ filter
✗ Is equivalent to toList >> List.filter >> fromList

Given Dict 4 (InnerNode Black "2" 2 (InnerNode Black "1" 1 Leaf Leaf) (InnerNode Black "4" 4 (InnerNode Red "3" 3 Leaf Leaf) Leaf))

    The black height is not consistent:
    
    Size: 2
    
     B "2"->2    
     ┌───┴───┐   
    🍁   B "4"->4
           ┌─┴──┐
          🍁   🍁
```

(Credit goes to @lydell for the nice tree printing)

---

A further improvement would be to not have a full `Dict` as a "Given" input. Right now, if you get a failing fuzz test, you can't create a separate dedicated test with the specific failing input because you can't create the `Dict`. At best you can (without temporarily exposing many type constructors) do `Dict.fromList [...]` but that may not create the same internal structure as the failing test, which can be important.

THis is the case because `dictFuzzer` is quite complicated and can be either a `fromList`, or a series of insert+remove steps, or another kind of tree, etc.

So a potential improvement would be to have `dictFuzzer` only give the building blocks (like a list of insert+remove operations), and for the test to build the dict from that. This way, one could easily create these separate tests.

I'm not sure I will work on this, but I think it would be very useful.