### PR TITLE
Run elm-review in test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "prettier": "^3.2.5"
     },
     "scripts": {
-        "test": "elm-verify-examples --run-tests && elm-test-rs",
+        "test": "elm-verify-examples --run-tests && elm-test-rs && elm-review",
         "postinstall": "elm-tooling install"
     },
     "author": "Leonardo Taglialegne",


### PR DESCRIPTION
This is part of the test but it's not run locally, which was surprising (or would be surprising later when CI reports a failure).