### PR TITLE
Speed up Dict.filter

### DIFF
--- a/src/FastDict.elm
+++ b/src/FastDict.elm
@@ -860,16 +860,17 @@ foldrInner func acc t =
 -}
 filter : (comparable -> v -> Bool) -> Dict comparable v -> Dict comparable v
 filter isGood dict =
-    foldl
-        (\k v d ->
+    foldr
+        (\k v acc ->
             if isGood k v then
-                insert k v d
+                ListWithLength.cons ( k, v ) acc
 
             else
-                d
+                acc
         )
-        empty
+        ListWithLength.empty
         dict
+        |> Internal.fromSortedList
 
 
 {-| Partition a dictionary according to some test. The first dictionary


### PR DESCRIPTION
Taken from 8aa8d18 in this repo's `faster-filter` branch. All credit goes to @miniBill, I'm just making a PR out of it before the idea gets lost to the abyss.

#5 is possibly still relevant but is tricky to implement. This is much faster as shown by these benchmarks (also made by @miniBill) than the previous implementation and `elm/core`, although it doesn't clearly show performance for smallish dicts (10, 100 elements).

![Screenshot from 2025-06-07 00-44-14](https://github.com/user-attachments/assets/e1c4825c-10b2-49d2-9003-ab81aa0972e3)
![Screenshot from 2025-06-07 00-44-28](https://github.com/user-attachments/assets/37a03f14-caf0-4971-badf-b8f4f3b21f30)

